### PR TITLE
fix Check member Roles logic

### DIFF
--- a/src/XbyK/XperienceCommunity.Authorization/Implementations/Authorization.cs
+++ b/src/XbyK/XperienceCommunity.Authorization/Implementations/Authorization.cs
@@ -40,7 +40,15 @@ namespace XperienceCommunity.Authorization.Implementations
                 // Check member Roles logic
                 if (!authorized && permissions.MemberRoles.Length != 0) {
                     onlyAuthenticatedCheck = false;
-                    authorized = (user.Roles.Intersect(permissions.MemberRoles, StringComparer.InvariantCultureIgnoreCase).Any());
+
+                    foreach (string userRole in user.Roles)
+                    {
+                        if (permissions.MemberRoles.Contains(userRole, StringComparer.InvariantCultureIgnoreCase))
+                        {
+                            authorized = true;
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/src/XbyK/XperienceCommunity.Authorization/Implementations/Authorization.cs
+++ b/src/XbyK/XperienceCommunity.Authorization/Implementations/Authorization.cs
@@ -38,7 +38,7 @@ namespace XperienceCommunity.Authorization.Implementations
                 }
 
                 // Check member Roles logic
-                if (!authorized && permissions.MemberRoles.Length == 0) {
+                if (!authorized && permissions.MemberRoles.Length != 0) {
                     onlyAuthenticatedCheck = false;
                     authorized = (user.Roles.Intersect(permissions.MemberRoles, StringComparer.InvariantCultureIgnoreCase).Any());
                 }


### PR DESCRIPTION
Hi @KenticoDevTrev 
I noticed that the current member roles logic doesn't work as intended—it only checks if the user is authorized but doesn't properly validate their role.

```
// Check member Roles logic
 if (!authorized && permissions.MemberRoles.Length == 0) {
      onlyAuthenticatedCheck = false;
      authorized = (user.Roles.Intersect(permissions.MemberRoles, StringComparer.InvariantCultureIgnoreCase).Any());
}
```
i.e. _if MemberRoles.Length == 0_, then _Roles.Intersect.._. doesn't make sense because MemberRoles list is empty. There should be != 0
